### PR TITLE
Add nights by payment chart

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -156,6 +156,7 @@ function App() {
                 selectedYear={selectedYear}
                 selectedMonth={selectedMonth}
                 availableYears={availableYears}
+                showUrssaf={showUrssaf}
               />
             </Grid>
           ))}

--- a/src/components/GiteCard.jsx
+++ b/src/components/GiteCard.jsx
@@ -66,11 +66,10 @@ function GiteCard({ name, data, selectedYear, selectedMonth, availableYears }) {
           <Box sx={{ flex: 1, minWidth: 250 }}>
             <Typography variant="subtitle2" color="text.secondary" mb={1}>Répartition des paiements</Typography>
             <PaymentPieChart payments={stats.payments} />
-          </Box>
-
-          <Box sx={{ flex: 1, minWidth: 250 }}>
-            <Typography variant="subtitle2" color="text.secondary" mb={1}>Nuitées par paiement</Typography>
-            <NuiteesPieChart nuitees={stats.nuiteesByPayment} />
+            <Box mt={2}>
+              <Typography variant="subtitle2" color="text.secondary" mb={1}>Nuitées par paiement</Typography>
+              <NuiteesPieChart nuitees={stats.nuiteesByPayment} />
+            </Box>
           </Box>
 
           <Box sx={{ flex: 2 }}>

--- a/src/components/GiteCard.jsx
+++ b/src/components/GiteCard.jsx
@@ -3,6 +3,7 @@ import { Card, CardContent, Typography, Stack, Box, Divider } from "@mui/materia
 import { computeGiteStats, getOccupationPerYear, daysInMonth, safeNum } from "../utils/dataUtils";
 import ProgressBarImpots from "./ProgressBarImpots";
 import PaymentPieChart from "./PaymentPieChart";
+import NuiteesPieChart from "./NuiteesPieChart";
 import OccupationGauge from "./OccupationGauge";
 
 const COLORS = ["#2D8CFF", "#43B77D", "#F5A623", "#7E5BEF", "#FE5C73"];
@@ -65,6 +66,11 @@ function GiteCard({ name, data, selectedYear, selectedMonth, availableYears }) {
           <Box sx={{ flex: 1, minWidth: 250 }}>
             <Typography variant="subtitle2" color="text.secondary" mb={1}>Répartition des paiements</Typography>
             <PaymentPieChart payments={stats.payments} />
+          </Box>
+
+          <Box sx={{ flex: 1, minWidth: 250 }}>
+            <Typography variant="subtitle2" color="text.secondary" mb={1}>Nuitées par paiement</Typography>
+            <NuiteesPieChart nuitees={stats.nuiteesByPayment} />
           </Box>
 
           <Box sx={{ flex: 2 }}>

--- a/src/components/GiteCard.jsx
+++ b/src/components/GiteCard.jsx
@@ -8,7 +8,7 @@ import OccupationGauge from "./OccupationGauge";
 
 const COLORS = ["#2D8CFF", "#43B77D", "#F5A623", "#7E5BEF", "#FE5C73"];
 
-function GiteCard({ name, data, selectedYear, selectedMonth, availableYears }) {
+function GiteCard({ name, data, selectedYear, selectedMonth, availableYears, showUrssaf }) {
   const stats = computeGiteStats(data, selectedYear, selectedMonth);
 
   // Pour les jauges d’occupation
@@ -66,10 +66,14 @@ function GiteCard({ name, data, selectedYear, selectedMonth, availableYears }) {
           <Box sx={{ flex: 1, minWidth: 250 }}>
             <Typography variant="subtitle2" color="text.secondary" mb={1}>Répartition des paiements</Typography>
             <PaymentPieChart payments={stats.payments} />
-            <Box mt={2}>
-              <Typography variant="subtitle2" color="text.secondary" mb={1}>Nuitées par paiement</Typography>
-              <NuiteesPieChart nuitees={stats.nuiteesByPayment} />
-            </Box>
+            {showUrssaf && (
+              <Box mt={2}>
+                <Typography variant="subtitle2" color="text.secondary" mb={1}>
+                  Nuitées par paiement
+                </Typography>
+                <NuiteesPieChart nuitees={stats.nuiteesByPayment} />
+              </Box>
+            )}
           </Box>
 
           <Box sx={{ flex: 2 }}>

--- a/src/components/NuiteesPieChart.jsx
+++ b/src/components/NuiteesPieChart.jsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from "recharts";
+
+const COLORS = [
+  "#2D8CFF", "#43B77D", "#F5A623", "#7E5BEF", "#FE5C73",
+  "#4CC3FA", "#FCBE5E", "#6BCB77", "#FFD700", "#BB86FC"
+];
+
+function NuiteesPieChart({ nuitees }) {
+  const data = Object.entries(nuitees || {})
+    .filter(([, value]) => value > 0)
+    .map(([name, value]) => ({ name, value: Math.round(value * 100) / 100 }));
+
+  if (!data.length) {
+    return <div style={{ color: "#bdbdbd", fontSize: 12 }}>Aucune nuitée</div>;
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={120}>
+      <PieChart>
+        <Pie
+          data={data}
+          dataKey="value"
+          nameKey="name"
+          cx="40%"
+          cy="50%"
+          innerRadius={28}
+          outerRadius={45}
+          fill="#8884d8"
+          labelLine={false}
+          isAnimationActive
+        >
+          {data.map((entry, i) => (
+            <Cell key={entry.name} fill={COLORS[i % COLORS.length]} />
+          ))}
+        </Pie>
+        <Legend
+          verticalAlign="middle"
+          align="right"
+          iconType="circle"
+          layout="vertical"
+          formatter={(value, entry) => `${value} : ${entry.payload.value}`}
+          wrapperStyle={{
+            fontSize: 12,
+            marginLeft: 8,
+            top: 15
+          }}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}
+
+export default NuiteesPieChart;

--- a/src/utils/dataUtils.js
+++ b/src/utils/dataUtils.js
@@ -96,6 +96,7 @@ function computeGiteStats(entries, year, month) {
     "Virement / chèque": 0,
     "Airbnb": 0,
     "Abritel": 0,
+    "Gites de France": 0,
   };
 
   filtered.forEach(e => {
@@ -103,12 +104,17 @@ function computeGiteStats(entries, year, month) {
     if (!payments[paymentType]) payments[paymentType] = 0; // Initialiser si pas encore fait
     payments[paymentType] += e.revenus || 0; // On additionne les revenus pour chaque type de paiement
 
-    const p = paymentType.toLowerCase();
+    const p = paymentType
+      .toLowerCase()
+      .replace(/[éèêë]/g, "e")
+      .replace(/[àâ]/g, "a");
     const nuitées = (e.nuits || 0) * (e.adultes || 0);
     if (p.includes("airbnb")) {
       nuiteesByPayment["Airbnb"] += nuitées;
     } else if (p.includes("abritel")) {
       nuiteesByPayment["Abritel"] += nuitées;
+    } else if (p.includes("gites de france")) {
+      nuiteesByPayment["Gites de France"] += nuitées;
     } else if (p.includes("virement") || p.includes("chèque") || p.includes("cheque")) {
       nuiteesByPayment["Virement / chèque"] += nuitées;
     }
@@ -169,7 +175,7 @@ function getOccupationPerYear(entries, allYears, selectedMonth) {
 }
 
 // Pour URSSAF
-const URSSAF_PAYMENTS = ["Abritel", "Airbnb", "Chèque", "Virement"];
+const URSSAF_PAYMENTS = ["Abritel", "Airbnb", "Chèque", "Virement", "Gites de France"];
 function computeUrssaf(data, selectedYear, selectedMonth) {
   // Phonsine, Gree, Edmond = Sébastien
   // Liberté = Soazig

--- a/src/utils/dataUtils.js
+++ b/src/utils/dataUtils.js
@@ -89,14 +89,30 @@ function computeGiteStats(entries, year, month) {
   const meanStay = reservations ? (totalNights / reservations) : 0;
   const meanPrice = totalNights ? (totalCA / totalNights) : 0;
 
-  // Répartition paiements
+  // Répartition paiements (CA)
   const payments = {};
-// On compte les paiements par type
-filtered.forEach(e => {
-  const paymentType = e.paiement && e.paiement.trim() ? e.paiement : "Indéfini"; // Si pas de paiement, on le note comme "Indéfini"
-  if (!payments[paymentType]) payments[paymentType] = 0; // Initialiser si pas encore fait
-  payments[paymentType] += e.revenus || 0; // On additionne les revenus pour chaque type de paiement
-});
+  // Répartition nuitées par groupe de paiement
+  const nuiteesByPayment = {
+    "Virement / chèque": 0,
+    "Airbnb": 0,
+    "Abritel": 0,
+  };
+
+  filtered.forEach(e => {
+    const paymentType = e.paiement && e.paiement.trim() ? e.paiement : "Indéfini"; // Si pas de paiement, on le note comme "Indéfini"
+    if (!payments[paymentType]) payments[paymentType] = 0; // Initialiser si pas encore fait
+    payments[paymentType] += e.revenus || 0; // On additionne les revenus pour chaque type de paiement
+
+    const p = paymentType.toLowerCase();
+    const nuitées = (e.nuits || 0) * (e.adultes || 0);
+    if (p.includes("airbnb")) {
+      nuiteesByPayment["Airbnb"] += nuitées;
+    } else if (p.includes("abritel")) {
+      nuiteesByPayment["Abritel"] += nuitées;
+    } else if (p.includes("virement") || p.includes("chèque") || p.includes("cheque")) {
+      nuiteesByPayment["Virement / chèque"] += nuitées;
+    }
+  });
 
 
   return {
@@ -105,7 +121,8 @@ filtered.forEach(e => {
     totalCA,
     meanStay,
     meanPrice,
-    payments
+    payments,
+    nuiteesByPayment
   };
 }
 


### PR DESCRIPTION
## Summary
- compute nights by payment group in data utils
- display new `NuiteesPieChart` in each gite card
- implement `NuiteesPieChart` component

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6889df5813848322911d476d88609669