### PR TITLE
feat: add averages for reservations, nights, and pricing

### DIFF
--- a/src/components/GiteCard.jsx
+++ b/src/components/GiteCard.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Card, CardContent, Typography, Stack, Box, Divider } from "@mui/material";
 import { TrendingUp, TrendingDown } from "@mui/icons-material";
-import { computeGiteStats, computeAverageCA, getOccupationPerYear } from "../utils/dataUtils";
+import { computeGiteStats, computeAverageCA, computeAverageReservations, computeAverageNights, computeAveragePrice, getOccupationPerYear } from "../utils/dataUtils";
 import ProgressBarImpots from "./ProgressBarImpots";
 import PaymentPieChart from "./PaymentPieChart";
 import NuiteesPieChart from "./NuiteesPieChart";
@@ -12,6 +12,9 @@ const COLORS = ["#2D8CFF", "#43B77D", "#F5A623", "#7E5BEF", "#FE5C73"];
 function GiteCard({ name, data, selectedYear, selectedMonth, availableYears, showUrssaf }) {
   const stats = computeGiteStats(data, selectedYear, selectedMonth);
   const averageCA = computeAverageCA(data, selectedYear, selectedMonth);
+  const averageReservations = computeAverageReservations(data, selectedYear, selectedMonth);
+  const averageNights = computeAverageNights(data, selectedYear, selectedMonth);
+  const averagePrice = computeAveragePrice(data, selectedYear, selectedMonth);
 
   // Pour les jauges d’occupation
   const occupations = getOccupationPerYear(data, availableYears, selectedMonth);
@@ -51,8 +54,42 @@ function GiteCard({ name, data, selectedYear, selectedMonth, availableYears, sho
         </Stack>
 
         <Stack direction="row" spacing={0} justifyContent="space-between" mb={1} flexWrap="wrap">
-          <Stat label="Réservations" value={stats.reservations} />
-          <Stat label="Nuits" value={stats.totalNights} />
+          <Stat
+            label="Réservations"
+            value={
+              <Box component="span" display="flex" flexDirection="column" alignItems="flex-start">
+                <Typography>{stats.reservations}</Typography>
+                <Box display="flex" alignItems="center" mt={0.2}>
+                  {stats.reservations >= averageReservations ? (
+                    <TrendingUp sx={{ fontSize: 16, color: "#43B77D" }} />
+                  ) : (
+                    <TrendingDown sx={{ fontSize: 16, color: "#e53935" }} />
+                  )}
+                  <Typography variant="caption" ml={0.5} color="text.secondary">
+                    {averageReservations.toFixed(1)}
+                  </Typography>
+                </Box>
+              </Box>
+            }
+          />
+          <Stat
+            label="Nuits"
+            value={
+              <Box component="span" display="flex" flexDirection="column" alignItems="flex-start">
+                <Typography>{stats.totalNights}</Typography>
+                <Box display="flex" alignItems="center" mt={0.2}>
+                  {stats.totalNights >= averageNights ? (
+                    <TrendingUp sx={{ fontSize: 16, color: "#43B77D" }} />
+                  ) : (
+                    <TrendingDown sx={{ fontSize: 16, color: "#e53935" }} />
+                  )}
+                  <Typography variant="caption" ml={0.5} color="text.secondary">
+                    {averageNights.toFixed(1)}
+                  </Typography>
+                </Box>
+              </Box>
+            }
+          />
           <Stat
             label="CA brut"
             value={
@@ -75,7 +112,26 @@ function GiteCard({ name, data, selectedYear, selectedMonth, availableYears, sho
           />
 
           <Stat label="Durée moy." value={stats.meanStay.toFixed(1) + " nuits"} />
-          <Stat label="Prix moy/nuit" value={stats.meanPrice.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })} />
+          <Stat
+            label="Prix moy/nuit"
+            value={
+              <Box component="span" display="flex" flexDirection="column" alignItems="flex-start">
+                <Typography>
+                  {stats.meanPrice.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })}
+                </Typography>
+                <Box display="flex" alignItems="center" mt={0.2}>
+                  {stats.meanPrice >= averagePrice ? (
+                    <TrendingUp sx={{ fontSize: 16, color: "#43B77D" }} />
+                  ) : (
+                    <TrendingDown sx={{ fontSize: 16, color: "#e53935" }} />
+                  )}
+                  <Typography variant="caption" ml={0.5} color="text.secondary">
+                    {averagePrice.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })}
+                  </Typography>
+                </Box>
+              </Box>
+            }
+          />
         </Stack>
 
         <Box mb={1}>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,8 +2,10 @@ import React from "react";
 import {
   Paper, Box, Typography, FormControl, InputLabel, Select, MenuItem, Switch, FormControlLabel, Divider, Stack
 } from "@mui/material";
+import { TrendingUp, TrendingDown } from "@mui/icons-material";
 import UrssafBox from "./UrssafBox";
 import ProgressBarImpots from "./ProgressBarImpots";
+import { computeAverageReservations, computeAverageNights, computeAverageCA } from "../utils/dataUtils";
 
 const months = [
   { value: null, label: "-- année entière --" },
@@ -32,6 +34,11 @@ function Header({
   const caBrut = globalStats.totalCA;
   const impot = caBrut * 0.06;
   const caNet = caBrut * 0.94;
+
+  const allEntries = Object.values(data).flat();
+  const avgReservations = computeAverageReservations(allEntries, selectedYear, selectedMonth);
+  const avgNights = computeAverageNights(allEntries, selectedYear, selectedMonth);
+  const avgCA = computeAverageCA(allEntries, selectedYear, selectedMonth);
   return (
     <Paper elevation={2} sx={{ p: 3, mb: 2, borderRadius: 4, bgcolor: "#fff", boxShadow: "0 4px 32px #ebebeb" }}>
       <Stack direction={{ xs: "column", sm: "row" }} spacing={3} alignItems="center" justifyContent="space-between">
@@ -88,9 +95,9 @@ function Header({
       <Divider sx={{ my: 2 }} />
 
       <Stack direction={{ xs: "column", sm: "row" }} spacing={2} alignItems="center" justifyContent="center">
-        <Typography variant="body1" fontWeight={600}>Total réservations : <span style={{ color: "#1976d2" }}>{globalStats.totalReservations}</span></Typography>
-        <Typography variant="body1" fontWeight={600}>Total nuits réservées : <span style={{ color: "#1976d2" }}>{globalStats.totalNights}</span></Typography>
-        <Typography variant="body1" fontWeight={600}>Chiffre d’affaire brut : <span style={{ color: "#388e3c" }}>{globalStats.totalCA.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })}</span></Typography>
+        <HeaderStat label="Total réservations" value={globalStats.totalReservations} average={avgReservations} />
+        <HeaderStat label="Total nuits réservées" value={globalStats.totalNights} average={avgNights} />
+        <HeaderStat label="Chiffre d’affaire brut" value={globalStats.totalCA} average={avgCA} isCurrency />
       </Stack>
 
       <Box mt={5} sx={{ maxWidth: "60%", mx: "auto" }}>
@@ -101,3 +108,30 @@ function Header({
 }
 
 export default Header;
+
+function HeaderStat({ label, value, average, isCurrency }) {
+  return (
+    <Box textAlign="center">
+      <Typography variant="body1" fontWeight={600}>{label}</Typography>
+      <Box display="flex" flexDirection="column" alignItems="center">
+        <Typography fontWeight={600} color={isCurrency ? "#388e3c" : "#1976d2"}>
+          {isCurrency
+            ? value.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })
+            : value}
+        </Typography>
+        <Box display="flex" alignItems="center" mt={0.2}>
+          {value >= average ? (
+            <TrendingUp sx={{ fontSize: 16, color: "#43B77D" }} />
+          ) : (
+            <TrendingDown sx={{ fontSize: 16, color: "#e53935" }} />
+          )}
+          <Typography variant="caption" ml={0.5} color="text.secondary">
+            {isCurrency
+              ? average.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })
+              : average.toFixed(1)}
+          </Typography>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/utils/dataUtils.js
+++ b/src/utils/dataUtils.js
@@ -138,14 +138,13 @@ function computeAverageMetric(entries, selectedYear, selectedMonth, metric) {
   const today = new Date();
   const thisYear = today.getFullYear();
 
-  // Liste des années disponibles, sauf celle sélectionnée
+  // Toutes les années dispo, sauf l'année sélectionnée
   const years = Array.from(new Set(
     entries.filter(e => e.debut).map(e => e.debut.getFullYear())
   ));
   const otherYears = years.filter(y => y !== selectedYear);
 
-  if (otherYears.length === 0) return 0;
-
+  // Helper pour calculer la valeur selon le metric demandé
   const computeValue = filtered => {
     if (metric === "CA") {
       return filtered.reduce((sum, e) => sum + (e.revenus || 0), 0);
@@ -168,13 +167,16 @@ function computeAverageMetric(entries, selectedYear, selectedMonth, metric) {
     .map(year => {
       let filtered;
 
+      // Si un mois est sélectionné, on compare les mois
       if (selectedMonth) {
         filtered = entries.filter(e =>
           e.debut &&
           e.debut.getFullYear() === year &&
           (e.debut.getMonth() + 1) === Number(selectedMonth)
         );
-      } else if (selectedYear === thisYear) {
+      } 
+      // Si l'année sélectionnée est l'année en cours
+      else if (selectedYear === thisYear) {
         const month = today.getMonth();
         const day = today.getDate();
         const start = new Date(year, 0, 1);
@@ -185,11 +187,28 @@ function computeAverageMetric(entries, selectedYear, selectedMonth, metric) {
           e.debut >= start &&
           e.debut < end
         );
-      } else {
-        filtered = entries.filter(e =>
-          e.debut &&
-          e.debut.getFullYear() === year
-        );
+      } 
+      // Si l'année sélectionnée est une année passée
+      else {
+        // Pour les autres années passées, on prend les 12 mois
+        if (year !== thisYear) {
+          filtered = entries.filter(e =>
+            e.debut &&
+            e.debut.getFullYear() === year
+          );
+        } else {
+          // Pour l'année en cours (2025) : on ne prend que les mois déjà passés
+          const month = today.getMonth();
+          const day = today.getDate();
+          const start = new Date(year, 0, 1);
+          const end = new Date(year, month, day + 1);
+          filtered = entries.filter(e =>
+            e.debut &&
+            e.debut.getFullYear() === year &&
+            e.debut >= start &&
+            e.debut < end
+          );
+        }
       }
 
       const value = computeValue(filtered);
@@ -200,6 +219,7 @@ function computeAverageMetric(entries, selectedYear, selectedMonth, metric) {
   const total = values.reduce((sum, v) => sum + v, 0);
   return values.length ? total / values.length : 0;
 }
+
 
 function computeAverageCA(entries, selectedYear, selectedMonth) {
   return computeAverageMetric(entries, selectedYear, selectedMonth, "CA");


### PR DESCRIPTION
## Summary
- add generic average calculator for CA, reservations, nights and price per night
- show historical averages with trend icons on each gîte card
- display overall averages for reservations, nights, and CA in header

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build` *(fails: Module not found: Can't resolve 'chart.js/helpers')*

------
https://chatgpt.com/codex/tasks/task_e_688c72fae7848322a9607fe7f2034b2f