### PR TITLE
feat: add stats toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,6 +45,8 @@ function App() {
 
   // Switch URSSAF
   const [showUrssaf, setShowUrssaf] = useState(false);
+  // Switch Stats
+  const [showStats, setShowStats] = useState(false);
 
   // Gestion années disponibles
   const [availableYears, setAvailableYears] = useState([]);
@@ -143,6 +145,8 @@ function App() {
           availableYears={availableYears}
           showUrssaf={showUrssaf}
           setShowUrssaf={setShowUrssaf}
+          showStats={showStats}
+          setShowStats={setShowStats}
           data={data}
           globalStats={globalStats}
         />
@@ -157,6 +161,7 @@ function App() {
                 selectedMonth={selectedMonth}
                 availableYears={availableYears}
                 showUrssaf={showUrssaf}
+                showStats={showStats}
               />
             </Grid>
           ))}

--- a/src/components/GiteCard.jsx
+++ b/src/components/GiteCard.jsx
@@ -9,7 +9,7 @@ import OccupationGauge from "./OccupationGauge";
 
 const COLORS = ["#2D8CFF", "#43B77D", "#F5A623", "#7E5BEF", "#FE5C73"];
 
-function GiteCard({ name, data, selectedYear, selectedMonth, availableYears, showUrssaf }) {
+function GiteCard({ name, data, selectedYear, selectedMonth, availableYears, showUrssaf, showStats }) {
   const stats = computeGiteStats(data, selectedYear, selectedMonth);
   const averageCA = computeAverageCA(data, selectedYear, selectedMonth);
   const averageReservations = computeAverageReservations(data, selectedYear, selectedMonth);
@@ -59,16 +59,18 @@ function GiteCard({ name, data, selectedYear, selectedMonth, availableYears, sho
             value={
               <Box component="span" display="flex" flexDirection="column" alignItems="flex-start">
                 <Typography>{stats.reservations}</Typography>
-                <Box display="flex" alignItems="center" mt={0.2}>
-                  {stats.reservations >= averageReservations ? (
-                    <TrendingUp sx={{ fontSize: 16, color: "#43B77D" }} />
-                  ) : (
-                    <TrendingDown sx={{ fontSize: 16, color: "#e53935" }} />
-                  )}
-                  <Typography variant="caption" ml={0.5} color="text.secondary">
-                    {averageReservations.toFixed(1)}
-                  </Typography>
-                </Box>
+                {showStats && (
+                  <Box display="flex" alignItems="center" mt={0.2}>
+                    {stats.reservations >= averageReservations ? (
+                      <TrendingUp sx={{ fontSize: 16, color: "#43B77D" }} />
+                    ) : (
+                      <TrendingDown sx={{ fontSize: 16, color: "#e53935" }} />
+                    )}
+                    <Typography variant="caption" ml={0.5} color="text.secondary">
+                      {averageReservations.toFixed(1)}
+                    </Typography>
+                  </Box>
+                )}
               </Box>
             }
           />
@@ -77,16 +79,18 @@ function GiteCard({ name, data, selectedYear, selectedMonth, availableYears, sho
             value={
               <Box component="span" display="flex" flexDirection="column" alignItems="flex-start">
                 <Typography>{stats.totalNights}</Typography>
-                <Box display="flex" alignItems="center" mt={0.2}>
-                  {stats.totalNights >= averageNights ? (
-                    <TrendingUp sx={{ fontSize: 16, color: "#43B77D" }} />
-                  ) : (
-                    <TrendingDown sx={{ fontSize: 16, color: "#e53935" }} />
-                  )}
-                  <Typography variant="caption" ml={0.5} color="text.secondary">
-                    {averageNights.toFixed(1)}
-                  </Typography>
-                </Box>
+                {showStats && (
+                  <Box display="flex" alignItems="center" mt={0.2}>
+                    {stats.totalNights >= averageNights ? (
+                      <TrendingUp sx={{ fontSize: 16, color: "#43B77D" }} />
+                    ) : (
+                      <TrendingDown sx={{ fontSize: 16, color: "#e53935" }} />
+                    )}
+                    <Typography variant="caption" ml={0.5} color="text.secondary">
+                      {averageNights.toFixed(1)}
+                    </Typography>
+                  </Box>
+                )}
               </Box>
             }
           />
@@ -97,16 +101,18 @@ function GiteCard({ name, data, selectedYear, selectedMonth, availableYears, sho
                 <Typography>
                   {stats.totalCA.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })}
                 </Typography>
-                <Box display="flex" alignItems="center" mt={0.2}>
-                  {stats.totalCA >= averageCA ? (
-                    <TrendingUp sx={{ fontSize: 16, color: "#43B77D" }} />
-                  ) : (
-                    <TrendingDown sx={{ fontSize: 16, color: "#e53935" }} />
-                  )}
-                  <Typography variant="caption" ml={0.5} color="text.secondary">
-                    {averageCA.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })}
-                  </Typography>
-                </Box>
+                {showStats && (
+                  <Box display="flex" alignItems="center" mt={0.2}>
+                    {stats.totalCA >= averageCA ? (
+                      <TrendingUp sx={{ fontSize: 16, color: "#43B77D" }} />
+                    ) : (
+                      <TrendingDown sx={{ fontSize: 16, color: "#e53935" }} />
+                    )}
+                    <Typography variant="caption" ml={0.5} color="text.secondary">
+                      {averageCA.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })}
+                    </Typography>
+                  </Box>
+                )}
               </Box>
             }
           />
@@ -119,16 +125,18 @@ function GiteCard({ name, data, selectedYear, selectedMonth, availableYears, sho
                 <Typography>
                   {stats.meanPrice.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })}
                 </Typography>
-                <Box display="flex" alignItems="center" mt={0.2}>
-                  {stats.meanPrice >= averagePrice ? (
-                    <TrendingUp sx={{ fontSize: 16, color: "#43B77D" }} />
-                  ) : (
-                    <TrendingDown sx={{ fontSize: 16, color: "#e53935" }} />
-                  )}
-                  <Typography variant="caption" ml={0.5} color="text.secondary">
-                    {averagePrice.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })}
-                  </Typography>
-                </Box>
+                {showStats && (
+                  <Box display="flex" alignItems="center" mt={0.2}>
+                    {stats.meanPrice >= averagePrice ? (
+                      <TrendingUp sx={{ fontSize: 16, color: "#43B77D" }} />
+                    ) : (
+                      <TrendingDown sx={{ fontSize: 16, color: "#e53935" }} />
+                    )}
+                    <Typography variant="caption" ml={0.5} color="text.secondary">
+                      {averagePrice.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })}
+                    </Typography>
+                  </Box>
+                )}
               </Box>
             }
           />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -28,6 +28,7 @@ function Header({
   selectedMonth, setSelectedMonth,
   availableYears,
   showUrssaf, setShowUrssaf,
+  showStats, setShowStats,
   data,
   globalStats
 }) {
@@ -73,16 +74,28 @@ function Header({
         </Box>
 
         <Box>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={showUrssaf}
-                onChange={e => setShowUrssaf(e.target.checked)}
-                color="primary"
-              />
-            }
-            label="Mode déclaration"
-          />
+          <Stack direction="row" spacing={2}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={showUrssaf}
+                  onChange={e => setShowUrssaf(e.target.checked)}
+                  color="primary"
+                />
+              }
+              label="Mode déclaration"
+            />
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={showStats}
+                  onChange={e => setShowStats(e.target.checked)}
+                  color="primary"
+                />
+              }
+              label="Stats"
+            />
+          </Stack>
         </Box>
       </Stack>
 
@@ -95,9 +108,9 @@ function Header({
       <Divider sx={{ my: 2 }} />
 
       <Stack direction={{ xs: "column", sm: "row" }} spacing={2} alignItems="center" justifyContent="center">
-        <HeaderStat label="Total réservations" value={globalStats.totalReservations} average={avgReservations} />
-        <HeaderStat label="Total nuits réservées" value={globalStats.totalNights} average={avgNights} />
-        <HeaderStat label="Chiffre d’affaire brut" value={globalStats.totalCA} average={avgCA} isCurrency />
+        <HeaderStat label="Total réservations" value={globalStats.totalReservations} average={avgReservations} showStats={showStats} />
+        <HeaderStat label="Total nuits réservées" value={globalStats.totalNights} average={avgNights} showStats={showStats} />
+        <HeaderStat label="Chiffre d’affaire brut" value={globalStats.totalCA} average={avgCA} isCurrency showStats={showStats} />
       </Stack>
 
       <Box mt={5} sx={{ maxWidth: "60%", mx: "auto" }}>
@@ -109,7 +122,7 @@ function Header({
 
 export default Header;
 
-function HeaderStat({ label, value, average, isCurrency }) {
+function HeaderStat({ label, value, average, isCurrency, showStats }) {
   return (
     <Box textAlign="center">
       <Typography variant="body1" fontWeight={600}>{label}</Typography>
@@ -119,18 +132,20 @@ function HeaderStat({ label, value, average, isCurrency }) {
             ? value.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })
             : value}
         </Typography>
-        <Box display="flex" alignItems="center" mt={0.2}>
-          {value >= average ? (
-            <TrendingUp sx={{ fontSize: 16, color: "#43B77D" }} />
-          ) : (
-            <TrendingDown sx={{ fontSize: 16, color: "#e53935" }} />
-          )}
-          <Typography variant="caption" ml={0.5} color="text.secondary">
-            {isCurrency
-              ? average.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })
-              : average.toFixed(1)}
-          </Typography>
-        </Box>
+        {showStats && (
+          <Box display="flex" alignItems="center" mt={0.2}>
+            {value >= average ? (
+              <TrendingUp sx={{ fontSize: 16, color: "#43B77D" }} />
+            ) : (
+              <TrendingDown sx={{ fontSize: 16, color: "#e53935" }} />
+            )}
+            <Typography variant="caption" ml={0.5} color="text.secondary">
+              {isCurrency
+                ? average.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })
+                : average.toFixed(1)}
+            </Typography>
+          </Box>
+        )}
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary
- add header Stats switch to toggle average indicators
- hide trend icons and averages when Stats is off

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688c7b942c748322ad7c986e786ffae2