### PR TITLE
feat: add global revenue chart

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import GiteCard from "./components/GiteCard";
 import { parseGitesData, getAvailableYears, filterDataByPeriod, computeGlobalStats } from "./utils/dataUtils";
 import "./index.css";
 import DebugCA from "./components/DebugCA";
+import GlobalRevenueChart from "./components/GlobalRevenueChart";
 
 const GITE_NAMES = ["Phonsine", "Gree", "Edmond", "Liberté"];
 const PASSWORD = "tellthem"; // ← Change-le si tu veux
@@ -166,6 +167,7 @@ function App() {
             </Grid>
           ))}
         </Grid>
+        <GlobalRevenueChart data={data} availableYears={availableYears} />
       </Container>
      {/*  <DebugCA data={data["Edmond"] || []} /> Composant de debug pour les données d'Edmond */}
     </>

--- a/src/components/GlobalRevenueChart.jsx
+++ b/src/components/GlobalRevenueChart.jsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { Paper, Typography, Box } from "@mui/material";
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Cell, LabelList } from "recharts";
+import { getMonthlyCAByYear } from "../utils/dataUtils";
+
+const MONTH_NAMES = ["Jan", "Fév", "Mar", "Avr", "Mai", "Juin", "Juil", "Août", "Sep", "Oct", "Nov", "Déc"];
+
+function GlobalRevenueChart({ data, availableYears }) {
+  const caByYear = getMonthlyCAByYear(data);
+
+  const getColor = (value, max) => {
+    const ratio = max ? value / max : 0;
+    const hue = 60 - ratio * 60; // 60 (jaune) -> 0 (rouge)
+    return `hsl(${hue}, 80%, 55%)`;
+  };
+
+  return (
+    <Paper elevation={2} sx={{ p: 3, mt: 4, borderRadius: 4, bgcolor: "#fff", boxShadow: "0 4px 32px #ebebeb" }}>
+      {availableYears.map(year => {
+        const months = caByYear[year]?.months || [];
+        const total = caByYear[year]?.total || 0;
+        const max = Math.max(...months.map(m => m.ca), 0);
+        return (
+          <Box key={year} mb={4}>
+            <Typography variant="h6" align="center" mb={2}>
+              {`Chiffre d'affaire ${year} (Total: ${total.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})})`}
+            </Typography>
+            <ResponsiveContainer width="100%" height={200}>
+              <BarChart data={months} margin={{ top: 20, right: 20, left: 0, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="month" tickFormatter={m => MONTH_NAMES[m - 1]} />
+                <YAxis />
+                <Tooltip formatter={value => value.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})} />
+                <Bar dataKey="ca">
+                  {months.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={getColor(entry.ca, max)} />
+                  ))}
+                  <LabelList dataKey="ca" position="top" formatter={value => value.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})} />
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </Box>
+        );
+      })}
+    </Paper>
+  );
+}
+
+export default GlobalRevenueChart;

--- a/src/utils/dataUtils.js
+++ b/src/utils/dataUtils.js
@@ -282,6 +282,30 @@ function getOccupationPerYear(entries, allYears, selectedMonth) {
   }));
 }
 
+// Chiffre d'affaire mensuel global par année
+function getMonthlyCAByYear(data) {
+  const result = {};
+  Object.values(data).forEach(entries => {
+    entries.forEach(e => {
+      if (!e.debut || isHomeExchange(e)) return;
+      const year = e.debut.getFullYear();
+      const month = e.debut.getMonth(); // 0-index
+      if (!result[year]) {
+        result[year] = Array(12).fill(0);
+      }
+      result[year][month] += e.revenus || 0;
+    });
+  });
+
+  const formatted = {};
+  Object.keys(result).forEach(year => {
+    const months = result[year].map((ca, idx) => ({ month: idx + 1, ca }));
+    const total = result[year].reduce((sum, v) => sum + v, 0);
+    formatted[year] = { months, total };
+  });
+  return formatted;
+}
+
 // Pour URSSAF
 const URSSAF_PAYMENTS = ["Abritel", "Airbnb", "Chèque", "Virement", "Gites de France"];
 function computeUrssaf(data, selectedYear, selectedMonth) {
@@ -325,6 +349,7 @@ module.exports = {
   computeAveragePrice,
   computeOccupation,
   getOccupationPerYear,
+  getMonthlyCAByYear,
   computeUrssaf,
   daysInMonth,
   safeNum


### PR DESCRIPTION
## Summary
- compute monthly gross revenue for all gites by year
- display annual bar charts with warm color scale and totals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c817b01648322959953202393084c