### PR TITLE
feat: add gîte selector for revenue charts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Container, Grid, CssBaseline, CircularProgress, Box, Typography } from "@mui/material";
+import { Container, Grid, CssBaseline, CircularProgress, Box, Typography, FormControl, InputLabel, Select, MenuItem } from "@mui/material";
 import Header from "./components/Header";
 import GiteCard from "./components/GiteCard";
 import { parseGitesData, getAvailableYears, filterDataByPeriod, computeGlobalStats } from "./utils/dataUtils";
@@ -43,6 +43,9 @@ function App() {
   const currentYear = new Date().getFullYear();
   const [selectedYear, setSelectedYear] = useState(currentYear);
   const [selectedMonth, setSelectedMonth] = useState(null); // null = année entière
+
+  // Sélection gîte pour les graphiques globaux
+  const [selectedGite, setSelectedGite] = useState("Tous");
 
   // Switch URSSAF
   const [showUrssaf, setShowUrssaf] = useState(false);
@@ -134,6 +137,9 @@ function App() {
     );
   }
 
+  const filteredData = selectedGite === "Tous" ? data : { [selectedGite]: data[selectedGite] || [] };
+  const yearsForChart = getAvailableYears(filteredData);
+
   return (
     <>
       <CssBaseline />
@@ -167,7 +173,21 @@ function App() {
             </Grid>
           ))}
         </Grid>
-        <GlobalRevenueChart data={data} availableYears={availableYears} />
+        <FormControl fullWidth sx={{ mt: 4 }}>
+          <InputLabel id="gite-select-label">Gîte</InputLabel>
+          <Select
+            labelId="gite-select-label"
+            value={selectedGite}
+            label="Gîte"
+            onChange={(e) => setSelectedGite(e.target.value)}
+          >
+            <MenuItem value="Tous">Tous les gîtes</MenuItem>
+            {GITE_NAMES.map(name => (
+              <MenuItem key={name} value={name}>{name}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <GlobalRevenueChart data={filteredData} availableYears={yearsForChart} selectedGite={selectedGite} />
       </Container>
      {/*  <DebugCA data={data["Edmond"] || []} /> Composant de debug pour les données d'Edmond */}
     </>

--- a/src/components/GlobalRevenueChart.jsx
+++ b/src/components/GlobalRevenueChart.jsx
@@ -5,7 +5,7 @@ import { getMonthlyCAByYear } from "../utils/dataUtils";
 
 const MONTH_NAMES = ["Jan", "Fév", "Mar", "Avr", "Mai", "Juin", "Juil", "Août", "Sep", "Oct", "Nov", "Déc"];
 
-function GlobalRevenueChart({ data, availableYears }) {
+function GlobalRevenueChart({ data, availableYears, selectedGite }) {
   const caByYear = getMonthlyCAByYear(data);
 
   const getColor = (value, max) => {
@@ -20,10 +20,11 @@ function GlobalRevenueChart({ data, availableYears }) {
         const months = caByYear[year]?.months || [];
         const total = caByYear[year]?.total || 0;
         const max = Math.max(...months.map(m => m.ca), 0);
+        const giteLabel = selectedGite && selectedGite !== "Tous" ? `${selectedGite} ` : "";
         return (
           <Box key={year} mb={4}>
             <Typography variant="h6" align="center" mb={2}>
-              {`Chiffre d'affaire ${year} (Total: ${total.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})})`}
+              {`Chiffre d'affaire ${giteLabel}${year} (Total: ${total.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})})`}
             </Typography>
             <ResponsiveContainer width="100%" height={200}>
               <BarChart data={months} margin={{ top: 20, right: 20, left: 0, bottom: 0 }}>


### PR DESCRIPTION
## Summary
- add MUI selector to filter revenue charts by gîte or all gîtes
- update global revenue chart to display selected gîte data

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688c896f25c88322a27e62780459f3c1