### PR TITLE
feat: add year option to global revenue charts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,8 +44,8 @@ function App() {
   const [selectedYear, setSelectedYear] = useState(currentYear);
   const [selectedMonth, setSelectedMonth] = useState(null); // null = année entière
 
-  // Sélection gîte pour les graphiques globaux
-  const [selectedGite, setSelectedGite] = useState("Tous");
+  // Sélection gîte ou année pour les graphiques globaux
+  const [selectedItem, setSelectedItem] = useState("Tous");
 
   // Switch URSSAF
   const [showUrssaf, setShowUrssaf] = useState(false);
@@ -137,8 +137,13 @@ function App() {
     );
   }
 
-  const filteredData = selectedGite === "Tous" ? data : { [selectedGite]: data[selectedGite] || [] };
-  const yearsForChart = getAvailableYears(filteredData);
+  const isYearSelection = typeof selectedItem === "number";
+  const chartData = isYearSelection
+    ? data
+    : selectedItem === "Tous"
+      ? data
+      : { [selectedItem]: data[selectedItem] || [] };
+  const labelsForChart = isYearSelection ? GITE_NAMES : getAvailableYears(chartData);
 
   return (
     <>
@@ -174,20 +179,23 @@ function App() {
           ))}
         </Grid>
         <FormControl fullWidth sx={{ mt: 4 }}>
-          <InputLabel id="gite-select-label">Gîte</InputLabel>
+          <InputLabel id="gite-select-label">Gîte ou année</InputLabel>
           <Select
             labelId="gite-select-label"
-            value={selectedGite}
-            label="Gîte"
-            onChange={(e) => setSelectedGite(e.target.value)}
+            value={selectedItem}
+            label="Gîte ou année"
+            onChange={(e) => setSelectedItem(e.target.value)}
           >
             <MenuItem value="Tous">Tous les gîtes</MenuItem>
             {GITE_NAMES.map(name => (
               <MenuItem key={name} value={name}>{name}</MenuItem>
             ))}
+            {availableYears.map(year => (
+              <MenuItem key={year} value={year}>{year}</MenuItem>
+            ))}
           </Select>
         </FormControl>
-        <GlobalRevenueChart data={filteredData} availableYears={yearsForChart} selectedGite={selectedGite} />
+        <GlobalRevenueChart data={chartData} labels={labelsForChart} selectedOption={selectedItem} />
       </Container>
      {/*  <DebugCA data={data["Edmond"] || []} /> Composant de debug pour les données d'Edmond */}
     </>

--- a/src/components/GlobalRevenueChart.jsx
+++ b/src/components/GlobalRevenueChart.jsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { Paper, Typography, Box } from "@mui/material";
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Cell, LabelList } from "recharts";
-import { getMonthlyCAByYear } from "../utils/dataUtils";
+import { getMonthlyCAByYear, getMonthlyCAByGiteForYear } from "../utils/dataUtils";
 
 const MONTH_NAMES = ["Jan", "Fév", "Mar", "Avr", "Mai", "Juin", "Juil", "Août", "Sep", "Oct", "Nov", "Déc"];
 
-function GlobalRevenueChart({ data, availableYears, selectedGite }) {
-  const caByYear = getMonthlyCAByYear(data);
+function GlobalRevenueChart({ data, labels, selectedOption }) {
+  const isYearSelected = typeof selectedOption === "number";
+  const caData = isYearSelected
+    ? getMonthlyCAByGiteForYear(data, selectedOption)
+    : getMonthlyCAByYear(data);
 
   const getColor = (value, max) => {
     const ratio = max ? value / max : 0;
@@ -16,15 +19,17 @@ function GlobalRevenueChart({ data, availableYears, selectedGite }) {
 
   return (
     <Paper elevation={2} sx={{ p: 3, mt: 4, borderRadius: 4, bgcolor: "#fff", boxShadow: "0 4px 32px #ebebeb" }}>
-      {availableYears.map(year => {
-        const months = caByYear[year]?.months || [];
-        const total = caByYear[year]?.total || 0;
+      {labels.map(label => {
+        const months = caData[label]?.months || [];
+        const total = caData[label]?.total || 0;
         const max = Math.max(...months.map(m => m.ca), 0);
-        const giteLabel = selectedGite && selectedGite !== "Tous" ? `${selectedGite} ` : "";
+        const title = isYearSelected
+          ? `Chiffre d'affaire ${label} ${selectedOption} (Total: ${total.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})})`
+          : `Chiffre d'affaire ${selectedOption !== "Tous" ? `${selectedOption} ` : ""}${label} (Total: ${total.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})})`;
         return (
-          <Box key={year} mb={4}>
+          <Box key={label} mb={4}>
             <Typography variant="h6" align="center" mb={2}>
-              {`Chiffre d'affaire ${giteLabel}${year} (Total: ${total.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})})`}
+              {title}
             </Typography>
             <ResponsiveContainer width="100%" height={200}>
               <BarChart data={months} margin={{ top: 20, right: 20, left: 0, bottom: 0 }}>

--- a/src/utils/dataUtils.js
+++ b/src/utils/dataUtils.js
@@ -306,6 +306,29 @@ function getMonthlyCAByYear(data) {
   return formatted;
 }
 
+function getMonthlyCAByGiteForYear(data, year) {
+  const result = {};
+  Object.entries(data).forEach(([gite, entries]) => {
+    entries.forEach(e => {
+      if (!e.debut || isHomeExchange(e)) return;
+      if (e.debut.getFullYear() !== year) return;
+      const month = e.debut.getMonth();
+      if (!result[gite]) {
+        result[gite] = Array(12).fill(0);
+      }
+      result[gite][month] += e.revenus || 0;
+    });
+  });
+
+  const formatted = {};
+  Object.keys(result).forEach(gite => {
+    const months = result[gite].map((ca, idx) => ({ month: idx + 1, ca }));
+    const total = result[gite].reduce((sum, v) => sum + v, 0);
+    formatted[gite] = { months, total };
+  });
+  return formatted;
+}
+
 // Pour URSSAF
 const URSSAF_PAYMENTS = ["Abritel", "Airbnb", "Chèque", "Virement", "Gites de France"];
 function computeUrssaf(data, selectedYear, selectedMonth) {
@@ -350,6 +373,7 @@ module.exports = {
   computeOccupation,
   getOccupationPerYear,
   getMonthlyCAByYear,
+  getMonthlyCAByGiteForYear,
   computeUrssaf,
   daysInMonth,
   safeNum


### PR DESCRIPTION
## Summary
- allow switching global revenue charts between per-year and per-gîte views
- include available years in selector and compute chart data accordingly

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688c8d564b408322b8ba86396e637459