### PR TITLE
feat: harmonize revenue charts and add averages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dashboard Gîtes V3
 
-Tableau de bord moderne pour la gestion de 4 gîtes, statistiques et visualisations dynamiques.
+Tableau de bord moderne pour la gestion de quatre gîtes. L'application permet de visualiser facilement les statistiques de réservation, les revenus et de nombreuses autres informations utiles.
 
 ## Installation
 
@@ -8,3 +8,28 @@ Tableau de bord moderne pour la gestion de 4 gîtes, statistiques et visualisati
 git clone <repo>
 cd dashboard-gites-v3
 npm install
+```
+
+## Démarrage
+
+```bash
+npm start
+```
+
+L'application est accessible sur <http://localhost:3000>. Les données sont récupérées via l'API définie dans la variable d'environnement `REACT_APP_GITES_API`.
+
+## Tests
+
+```bash
+npm test
+```
+
+## Technologies principales
+
+- [React](https://reactjs.org/)
+- [Material UI](https://mui.com/)
+- [Recharts](https://recharts.org/)
+
+## Contribution
+
+Les contributions sont les bienvenues. N'hésitez pas à proposer des améliorations ou à ouvrir des issues pour signaler un problème.

--- a/src/components/GlobalRevenueChart.jsx
+++ b/src/components/GlobalRevenueChart.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Paper, Typography, Box } from "@mui/material";
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Cell, LabelList } from "recharts";
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Cell, LabelList, ReferenceLine } from "recharts";
 import { getMonthlyCAByYear, getMonthlyCAByGiteForYear } from "../utils/dataUtils";
 
 const MONTH_NAMES = ["Jan", "Fév", "Mar", "Avr", "Mai", "Juin", "Juil", "Août", "Sep", "Oct", "Nov", "Déc"];
@@ -11,12 +11,16 @@ function GlobalRevenueChart({ data, labels, selectedOption }) {
     ? getMonthlyCAByGiteForYear(data, selectedOption)
     : getMonthlyCAByYear(data);
 
-  // Determine the highest monthly revenue across all charts to
-  // ensure each graph shares the same Y-axis scale
+  // On détermine le CA mensuel le plus élevé tous graphiques confondus
+  // pour partager la même échelle verticale entre eux
   const globalMax = Math.max(
     ...labels.flatMap(label => (caData[label]?.months || []).map(m => m.ca)),
     0
   );
+  // Arrondir à la centaine supérieure afin d'obtenir une dernière graduation cohérente
+  const yAxisMax = Math.max(100, Math.ceil(globalMax / 100) * 100);
+  // Générer des paliers harmonisés de 100 €
+  const ticks = Array.from({ length: yAxisMax / 100 + 1 }, (_, i) => i * 100);
 
   const getColor = (value, max) => {
     const ratio = max ? value / max : 0;
@@ -30,6 +34,16 @@ function GlobalRevenueChart({ data, labels, selectedOption }) {
         const months = caData[label]?.months || [];
         const total = caData[label]?.total || 0;
         const max = Math.max(...months.map(m => m.ca), 0);
+        // Calcul de la moyenne mensuelle : si l'année représentée est l'année en cours,
+        // on ne prend en compte que les mois déjà passés
+        const currentYear = new Date().getFullYear();
+        const yearForData = isYearSelected ? selectedOption : Number(label);
+        const monthsForAverage = months.filter(m =>
+          yearForData === currentYear ? m.month <= new Date().getMonth() + 1 : true
+        );
+        const average = monthsForAverage.length
+          ? monthsForAverage.reduce((sum, m) => sum + m.ca, 0) / monthsForAverage.length
+          : 0;
         const title = isYearSelected
           ? `Chiffre d'affaire ${label} ${selectedOption} (Total: ${total.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})})`
           : `Chiffre d'affaire ${selectedOption !== "Tous" ? `${selectedOption} ` : ""}${label} (Total: ${total.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})})`;
@@ -42,19 +56,35 @@ function GlobalRevenueChart({ data, labels, selectedOption }) {
               <BarChart data={months} margin={{ top: 20, right: 20, left: 0, bottom: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="month" tickFormatter={m => MONTH_NAMES[m - 1]} />
-                <YAxis domain={[0, globalMax]} />
-                <Tooltip formatter={value => value.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})} />
-                <Bar dataKey="ca">
-                  {months.map((entry, index) => (
-                    <Cell key={`cell-${index}`} fill={getColor(entry.ca, max)} />
-                  ))}
-                  <LabelList dataKey="ca" position="top" formatter={value => value.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})} />
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
-          </Box>
-        );
-      })}
+                  <YAxis domain={[0, yAxisMax]} ticks={ticks} />
+                  <Tooltip formatter={value => value.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})} />
+                  <Bar dataKey="ca">
+                    {months.map((entry, index) => (
+                      <Cell key={`cell-${index}`} fill={getColor(entry.ca, max)} />
+                    ))}
+                    <LabelList
+                      dataKey="ca"
+                      position="top"
+                      formatter={value => value.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})}
+                    />
+                  </Bar>
+                  {/* Ligne en pointillés grise représentant la moyenne */}
+                  <ReferenceLine
+                    y={average}
+                    stroke="#888"
+                    strokeDasharray="3 3"
+                    label={{
+                      value: average.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'}),
+                      position: 'right',
+                      fill: '#888',
+                      fontSize: 12
+                    }}
+                  />
+                </BarChart>
+              </ResponsiveContainer>
+            </Box>
+          );
+        })}
     </Paper>
   );
 }


### PR DESCRIPTION
## Summary
- harmonize Y-axis scale for revenue charts, rounding to next 100 and adding uniform ticks
- display grey average line per chart with existing logic
- expand French README and commentary

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688cb77a7f2083228d6336fe3b870f11