### PR TITLE
Show cheque/virement nights per gîte in URSSAF box

### DIFF
--- a/src/components/UrssafBox.jsx
+++ b/src/components/UrssafBox.jsx
@@ -26,7 +26,7 @@ function UrssafBox({ data, selectedYear, selectedMonth }) {
         {gites.map(name => (
           <Stack key={name} spacing={0.5} alignItems="center">
             <Typography variant="caption" fontWeight={700}>{name}</Typography>
-            <Typography variant="caption">{nightsByGite[name] || 0}</Typography>
+            <Typography variant="caption">{nightsByGite[name] || 0} nuitées</Typography>
           </Stack>
         ))}
       </Stack>

--- a/src/components/UrssafBox.jsx
+++ b/src/components/UrssafBox.jsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { Paper, Typography, Stack } from "@mui/material";
-import { computeUrssaf } from "../utils/dataUtils";
+import { computeUrssaf, computeChequeVirementNights } from "../utils/dataUtils";
 
 function UrssafBox({ data, selectedYear, selectedMonth }) {
   const { urssafSeb, urssafSoazig } = computeUrssaf(data, selectedYear, selectedMonth);
+  const nightsByGite = computeChequeVirementNights(data, selectedYear, selectedMonth);
+  const gites = ["Phonsine", "Gree", "Edmond", "Liberté"];
   return (
     <Paper elevation={0} sx={{ bgcolor: "#f7f8fa", borderRadius: 3, p: 2, mb: 1, border: "1px solid #e0e0e0" }}>
       <Stack direction={{ xs: "column", sm: "row" }} spacing={3} alignItems="center" justifyContent="center">
@@ -19,6 +21,14 @@ function UrssafBox({ data, selectedYear, selectedMonth }) {
             {urssafSoazig.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })}
           </span>
         </Typography>
+      </Stack>
+      <Stack direction="row" spacing={2} justifyContent="center" mt={1}>
+        {gites.map(name => (
+          <Stack key={name} spacing={0.5} alignItems="center">
+            <Typography variant="caption" fontWeight={700}>{name}</Typography>
+            <Typography variant="caption">{nightsByGite[name] || 0}</Typography>
+          </Stack>
+        ))}
       </Stack>
     </Paper>
   );

--- a/src/utils/dataUtils.js
+++ b/src/utils/dataUtils.js
@@ -352,6 +352,26 @@ function computeUrssaf(data, selectedYear, selectedMonth) {
   });
   return { urssafSeb, urssafSoazig };
 }
+
+function computeChequeVirementNights(data, selectedYear, selectedMonth) {
+  const result = {};
+  Object.keys(data).forEach(name => {
+    let nights = 0;
+    (data[name] || []).forEach(e => {
+      if (entryMatch(e, selectedYear, selectedMonth)) {
+        const p = (e.paiement || '')
+          .toLowerCase()
+          .replace(/[éèêë]/g, 'e')
+          .replace(/[àâ]/g, 'a');
+        if (p.includes('virement') || p.includes('cheque')) {
+          nights += (e.nuits || 0) * (e.adultes || 0);
+        }
+      }
+    });
+    result[name] = nights;
+  });
+  return result;
+}
 function entryMatch(e, year, month) {
   if (!e.debut) return false;
   const y = e.debut.getFullYear();
@@ -374,6 +394,7 @@ module.exports = {
   getOccupationPerYear,
   getMonthlyCAByYear,
   getMonthlyCAByGiteForYear,
+  computeChequeVirementNights,
   computeUrssaf,
   daysInMonth,
   safeNum


### PR DESCRIPTION
## Summary
- compute cheque/virement nights per gîte
- list each gîte and its cheque/virement nights in URSSAF header

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688cdda11c4083229285784efd634655