### PR TITLE
Add monthly average line to revenue charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ Tableau de bord moderne pour la gestion de 4 gîtes, statistiques et visualisati
 git clone <repo>
 cd dashboard-gites-v3
 npm install
+
+```
+
+## Fonctionnalités
+
+- Graphiques de chiffre d'affaire avec ligne de moyenne mensuelle.

--- a/src/components/GlobalRevenueChart.jsx
+++ b/src/components/GlobalRevenueChart.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Paper, Typography, Box } from "@mui/material";
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Cell, LabelList } from "recharts";
-import { getMonthlyCAByYear, getMonthlyCAByGiteForYear } from "../utils/dataUtils";
+import { ComposedChart, Bar, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Cell, LabelList } from "recharts";
+import { getMonthlyCAByYear, getMonthlyCAByGiteForYear, getMonthlyAverageCA } from "../utils/dataUtils";
 
 const MONTH_NAMES = ["Jan", "Fév", "Mar", "Avr", "Mai", "Juin", "Juil", "Août", "Sep", "Oct", "Nov", "Déc"];
 
@@ -10,9 +10,8 @@ function GlobalRevenueChart({ data, labels, selectedOption }) {
   const caData = isYearSelected
     ? getMonthlyCAByGiteForYear(data, selectedOption)
     : getMonthlyCAByYear(data);
+  const overallAvg = isYearSelected ? null : getMonthlyAverageCA(data);
 
-  // Determine the highest monthly revenue across all charts to
-  // ensure each graph shares the same Y-axis scale
   const globalMax = Math.max(
     ...labels.flatMap(label => (caData[label]?.months || []).map(m => m.ca)),
     0
@@ -29,28 +28,36 @@ function GlobalRevenueChart({ data, labels, selectedOption }) {
       {labels.map(label => {
         const months = caData[label]?.months || [];
         const total = caData[label]?.total || 0;
+        const avgMonths = isYearSelected
+          ? getMonthlyAverageCA({ [label]: data[label] || [] })
+          : overallAvg;
+        const chartData = months.map((m, idx) => ({ ...m, avg: avgMonths[idx]?.ca || 0 }));
         const max = Math.max(...months.map(m => m.ca), 0);
-        const title = isYearSelected
-          ? `Chiffre d'affaire ${label} ${selectedOption} (Total: ${total.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})})`
-          : `Chiffre d'affaire ${selectedOption !== "Tous" ? `${selectedOption} ` : ""}${label} (Total: ${total.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})})`;
+        const graphTitle = isYearSelected
+          ? `Chiffre d'affaire ${label} ${selectedOption}`
+          : `Chiffre d'affaire ${selectedOption !== "Tous" ? `${selectedOption} ` : ""}${label}`;
         return (
           <Box key={label} mb={4}>
-            <Typography variant="h6" align="center" mb={2}>
-              {title}
-            </Typography>
-            <ResponsiveContainer width="100%" height={200}>
-              <BarChart data={months} margin={{ top: 20, right: 20, left: 0, bottom: 0 }}>
+            <Box textAlign="center" mb={1}>
+              <Typography variant="h6" fontWeight={600}>{graphTitle}</Typography>
+              <Typography variant="subtitle2" color="primary" fontWeight={500}>
+                {total.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})}
+              </Typography>
+            </Box>
+            <ResponsiveContainer width="100%" height={220}>
+              <ComposedChart data={chartData} margin={{ top: 20, right: 20, left: 0, bottom: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="month" tickFormatter={m => MONTH_NAMES[m - 1]} />
                 <YAxis domain={[0, globalMax]} />
                 <Tooltip formatter={value => value.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})} />
+                <Line type="monotone" dataKey="avg" stroke="#bbb" strokeWidth={2} dot={false} />
                 <Bar dataKey="ca">
-                  {months.map((entry, index) => (
+                  {chartData.map((entry, index) => (
                     <Cell key={`cell-${index}`} fill={getColor(entry.ca, max)} />
                   ))}
                   <LabelList dataKey="ca" position="top" formatter={value => value.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})} />
                 </Bar>
-              </BarChart>
+              </ComposedChart>
             </ResponsiveContainer>
           </Box>
         );

--- a/src/utils/dataUtils.js
+++ b/src/utils/dataUtils.js
@@ -329,6 +329,19 @@ function getMonthlyCAByGiteForYear(data, year) {
   return formatted;
 }
 
+function getMonthlyAverageCA(data) {
+  const byYear = getMonthlyCAByYear(data);
+  const years = Object.keys(byYear);
+  const count = years.length;
+  const sums = Array(12).fill(0);
+  years.forEach(year => {
+    byYear[year].months.forEach((m, idx) => {
+      sums[idx] += m.ca;
+    });
+  });
+  return sums.map((sum, idx) => ({ month: idx + 1, ca: count ? sum / count : 0 }));
+}
+
 // Pour URSSAF
 const URSSAF_PAYMENTS = ["Abritel", "Airbnb", "Chèque", "Virement", "Gites de France"];
 function computeUrssaf(data, selectedYear, selectedMonth) {
@@ -394,6 +407,7 @@ module.exports = {
   getOccupationPerYear,
   getMonthlyCAByYear,
   getMonthlyCAByGiteForYear,
+  getMonthlyAverageCA,
   computeChequeVirementNights,
   computeUrssaf,
   daysInMonth,


### PR DESCRIPTION
## Summary
- overlay grey line showing monthly average CA
- modernize revenue chart headers
- document new average line feature

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688d0d65f7ac8322a5fbe4b58b4024c4