### PR TITLE
Harmoniser échelle CA et docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ npm install
 
 ```
 
+## Utilisation
+
+- `npm start` : lance l'application en mode développement.
+- `npm test` : exécute la suite de tests.
+- `npm run build` : génère une version de production.
+
 ## Fonctionnalités
 
-- Graphiques de chiffre d'affaire avec ligne de moyenne mensuelle.
+- Graphiques de chiffre d'affaires avec ligne de moyenne mensuelle.
+- Statistiques globales et par gîte (réservations, nuits, CA...).
+- Répartition des paiements et des nuitées par plateforme.
+- Jauges d'occupation ou de chiffre d'affaires par année.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "dashboard-gites-v3",
-  "version": "1.0.0",
+  "version": "1.0.1",
+  "description": "Tableau de bord des gîtes avec statistiques détaillées",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.11.1",

--- a/src/components/GiteCard.jsx
+++ b/src/components/GiteCard.jsx
@@ -1,39 +1,41 @@
-import React from "react";
-import { Card, CardContent, Typography, Stack, Box, Divider } from "@mui/material";
-import { TrendingUp, TrendingDown } from "@mui/icons-material";
-import { computeGiteStats, computeAverageCA, computeAverageReservations, computeAverageNights, computeAveragePrice, getOccupationPerYear } from "../utils/dataUtils";
-import ProgressBarImpots from "./ProgressBarImpots";
-import PaymentPieChart from "./PaymentPieChart";
-import NuiteesPieChart from "./NuiteesPieChart";
-import OccupationGauge from "./OccupationGauge";
+// Carte récapitulative pour chaque gîte
+import React from 'react';
+import { Card, CardContent, Typography, Stack, Box, Divider } from '@mui/material';
+import { TrendingUp, TrendingDown } from '@mui/icons-material';
+import { computeGiteStats, computeAverageCA, computeAverageReservations, computeAverageNights, computeAveragePrice, getOccupationPerYear } from '../utils/dataUtils';
+import ProgressBarImpots from './ProgressBarImpots';
+import PaymentPieChart from './PaymentPieChart';
+import NuiteesPieChart from './NuiteesPieChart';
+import OccupationGauge from './OccupationGauge';
 
-const COLORS = ["#2D8CFF", "#43B77D", "#F5A623", "#7E5BEF", "#FE5C73"];
+// Palette de couleurs utilisée pour les titres
+const COLORS = ['#2D8CFF', '#43B77D', '#F5A623', '#7E5BEF', '#FE5C73'];
 
 function GiteCard({ name, data, selectedYear, selectedMonth, availableYears, showUrssaf, showStats }) {
+  // Statistiques principales pour la période choisie
   const stats = computeGiteStats(data, selectedYear, selectedMonth);
+  // Moyennes annuelles pour comparaison
   const averageCA = computeAverageCA(data, selectedYear, selectedMonth);
   const averageReservations = computeAverageReservations(data, selectedYear, selectedMonth);
   const averageNights = computeAverageNights(data, selectedYear, selectedMonth);
   const averagePrice = computeAveragePrice(data, selectedYear, selectedMonth);
 
-  // Pour les jauges d’occupation
+  // Calcul des taux d’occupation pour les années disponibles
   const occupations = getOccupationPerYear(data, availableYears, selectedMonth);
 
-  // Pour la progress bar impôts
+  // Données pour la barre d'impôt (94 % net, 6 % impôt)
   const impot = stats.totalCA * 0.06;
   const caNet = stats.totalCA * 0.94;
 
-  // Pour la vue CA
+  // Préparation des données de CA annuel pour les jauges (mode CA)
   const caByYear = {};
   let maxCA = 0;
-
   availableYears.forEach(year => {
-    // Filtrer pour l'année + mois si besoin
+    // Filtrer pour l'année et le mois éventuel
     let entries = data.filter(e =>
       e.debut &&
       e.debut.getFullYear() === year &&
-      (selectedMonth === "" || (e.debut.getMonth() + 1) === Number(selectedMonth))
-      // + filtre HomeExchange ici si tu l’as fait
+      (selectedMonth === '' || (e.debut.getMonth() + 1) === Number(selectedMonth))
     );
     const ca = entries.reduce((sum, e) => sum + (e.revenus || 0), 0);
     caByYear[year] = ca;
@@ -48,12 +50,14 @@ function GiteCard({ name, data, selectedYear, selectedMonth, availableYears, sho
       boxShadow: "0 2px 16px #e5e5e5"
     }}>
       <CardContent>
-        <Stack direction="row" justifyContent="space-between" alignItems="center" mb={1}>
-          <Typography variant="h6" fontWeight={700} color={COLORS[0]}>{name}</Typography>
-          <Typography variant="body2" color="#bdbdbd">{selectedMonth ? `Mois ${selectedMonth}/${selectedYear}` : selectedYear}</Typography>
+        {/* En-tête de la carte avec période sélectionnée */}
+        <Stack direction='row' justifyContent='space-between' alignItems='center' mb={1}>
+          <Typography variant='h6' fontWeight={700} color={COLORS[0]}>{name}</Typography>
+          <Typography variant='body2' color='#bdbdbd'>{selectedMonth ? `Mois ${selectedMonth}/${selectedYear}` : selectedYear}</Typography>
         </Stack>
 
-        <Stack direction="row" spacing={0} justifyContent="space-between" mb={1} flexWrap="wrap">
+        {/* Statistiques principales */}
+        <Stack direction='row' spacing={0} justifyContent='space-between' mb={1} flexWrap='wrap'>
           <Stat
             label="Réservations"
             value={
@@ -142,24 +146,28 @@ function GiteCard({ name, data, selectedYear, selectedMonth, availableYears, sho
           />
         </Stack>
 
+        {/* Barre indiquant la part d'impôt */}
         <Box mb={1}>
           <ProgressBarImpots caBrut={stats.totalCA} caNet={caNet} impot={impot} />
         </Box>
 
         <Divider sx={{ my: 2 }} />
 
-        <Stack direction={{ xs: "column", sm: "row" }} spacing={2} alignItems="flex-start" justifyContent="space-between">
+        {/* Graphiques complémentaires : paiements, nuitées et taux d'occupation */}
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems='flex-start' justifyContent='space-between'>
           <Box sx={{ width: 250, minWidth: 250, maxWidth: 250, mx: "auto" }}>
-            <Typography variant="subtitle2" color="text.secondary" mb={1}>Répartition des paiements</Typography>
-            <Box sx={{ mb: 3 }}> {/* Ajoute une marge sous le camembert */}
+            <Typography variant='subtitle2' color='text.secondary' mb={1}>Répartition des paiements</Typography>
+            {/* Camembert des modes de paiement */}
+            <Box sx={{ mb: 3 }}>
               <PaymentPieChart payments={stats.payments} />
             </Box>
             {showUrssaf && (
               <>
-                <Typography variant="subtitle2" color="text.secondary" mb={1}>
+                <Typography variant='subtitle2' color='text.secondary' mb={1}>
                   Nuitées par paiement
                 </Typography>
-                <Box sx={{ mb: 1, pl: 0 }}> {/* Ajoute un padding-top pour écarter la légende du camembert */}
+                {/* Camembert indiquant les nuitées par type de paiement */}
+                <Box sx={{ mb: 1, pl: 0 }}>
                   <NuiteesPieChart nuitees={stats.nuiteesByPayment} />
                 </Box>
               </>
@@ -168,7 +176,7 @@ function GiteCard({ name, data, selectedYear, selectedMonth, availableYears, sho
 
 
           <Box sx={{ flex: 2 }}>
-            <Typography variant="subtitle2" color="text.secondary" mb={1}>Taux d’occupation</Typography>
+            <Typography variant='subtitle2' color='text.secondary' mb={1}>Taux d’occupation</Typography>
             <OccupationGauge
               occupations={occupations}
               selectedYear={selectedYear}

--- a/src/components/GlobalRevenueChart.jsx
+++ b/src/components/GlobalRevenueChart.jsx
@@ -3,20 +3,30 @@ import { Paper, Typography, Box } from "@mui/material";
 import { ComposedChart, Bar, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Cell, LabelList } from "recharts";
 import { getMonthlyCAByYear, getMonthlyCAByGiteForYear, getMonthlyAverageCA } from "../utils/dataUtils";
 
-const MONTH_NAMES = ["Jan", "Fév", "Mar", "Avr", "Mai", "Juin", "Juil", "Août", "Sep", "Oct", "Nov", "Déc"];
+// Libellés des mois affichés sur l'axe des abscisses
+const MONTH_NAMES = ['Jan', 'Fév', 'Mar', 'Avr', 'Mai', 'Juin', 'Juil', 'Août', 'Sep', 'Oct', 'Nov', 'Déc'];
 
 function GlobalRevenueChart({ data, labels, selectedOption }) {
-  const isYearSelected = typeof selectedOption === "number";
+  // Détermine si l'utilisateur a choisi une année précise
+  const isYearSelected = typeof selectedOption === 'number';
+  // Récupération des données de CA selon le mode sélectionné
   const caData = isYearSelected
     ? getMonthlyCAByGiteForYear(data, selectedOption)
     : getMonthlyCAByYear(data);
+  // Moyennes mensuelles (toutes années confondues)
   const overallAvg = isYearSelected ? null : getMonthlyAverageCA(data);
 
+  // Maximum global de toutes les valeurs affichées
   const globalMax = Math.max(
     ...labels.flatMap(label => (caData[label]?.months || []).map(m => m.ca)),
     0
   );
+  // Arrondi à la centaine supérieure pour l'échelle
+  const roundedMax = Math.ceil(globalMax / 100) * 100;
+  // Génération des paliers tous les 100 €
+  const ticks = Array.from({ length: roundedMax / 100 + 1 }, (_, i) => i * 100);
 
+  // Calcul de la couleur de chaque barre selon son pourcentage du max
   const getColor = (value, max) => {
     const ratio = max ? value / max : 0;
     const hue = 60 - ratio * 60; // 60 (jaune) -> 0 (rouge)
@@ -26,16 +36,22 @@ function GlobalRevenueChart({ data, labels, selectedOption }) {
   return (
     <Paper elevation={2} sx={{ p: 3, mt: 4, borderRadius: 4, bgcolor: "#fff", boxShadow: "0 4px 32px #ebebeb" }}>
       {labels.map(label => {
+        // Données mensuelles pour le gîte ou l'année en cours
         const months = caData[label]?.months || [];
+        // Total annuel pour affichage sous le titre
         const total = caData[label]?.total || 0;
+        // Moyenne mensuelle à afficher en ligne grise
         const avgMonths = isYearSelected
           ? getMonthlyAverageCA({ [label]: data[label] || [] })
           : overallAvg;
+        // Fusion des données de CA et des moyennes
         const chartData = months.map((m, idx) => ({ ...m, avg: avgMonths[idx]?.ca || 0 }));
+        // Maximum local pour déterminer la couleur des barres
         const max = Math.max(...months.map(m => m.ca), 0);
+        // Titre dynamique selon l'option sélectionnée
         const graphTitle = isYearSelected
           ? `Chiffre d'affaire ${label} ${selectedOption}`
-          : `Chiffre d'affaire ${selectedOption !== "Tous" ? `${selectedOption} ` : ""}${label}`;
+          : `Chiffre d'affaire ${selectedOption !== 'Tous' ? `${selectedOption} ` : ''}${label}`;
         return (
           <Box key={label} mb={4}>
             <Box textAlign="center" mb={1}>
@@ -47,15 +63,17 @@ function GlobalRevenueChart({ data, labels, selectedOption }) {
             <ResponsiveContainer width="100%" height={220}>
               <ComposedChart data={chartData} margin={{ top: 20, right: 20, left: 0, bottom: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="month" tickFormatter={m => MONTH_NAMES[m - 1]} />
-                <YAxis domain={[0, globalMax]} />
+                <XAxis dataKey='month' tickFormatter={m => MONTH_NAMES[m - 1]} />
+                {/* Échelle harmonisée avec un maximum arrondi et des paliers réguliers */}
+                <YAxis domain={[0, roundedMax]} ticks={ticks} />
                 <Tooltip formatter={value => value.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})} />
                 <Line type="monotone" dataKey="avg" stroke="#bbb" strokeWidth={2} dot={false} />
                 <Bar dataKey="ca">
                   {chartData.map((entry, index) => (
                     <Cell key={`cell-${index}`} fill={getColor(entry.ca, max)} />
                   ))}
-                  <LabelList dataKey="ca" position="top" formatter={value => value.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})} />
+                  {/* Affiche la valeur de chaque barre au sommet */}
+                  <LabelList dataKey='ca' position='top' formatter={value => value.toLocaleString('fr-FR',{ style:'currency', currency:'EUR'})} />
                 </Bar>
               </ComposedChart>
             </ResponsiveContainer>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,26 +1,28 @@
-import React from "react";
+// En-tête principal contenant filtres et statistiques globales
+import React from 'react';
 import {
   Paper, Box, Typography, FormControl, InputLabel, Select, MenuItem, Switch, FormControlLabel, Divider, Stack
-} from "@mui/material";
-import { TrendingUp, TrendingDown } from "@mui/icons-material";
-import UrssafBox from "./UrssafBox";
-import ProgressBarImpots from "./ProgressBarImpots";
-import { computeAverageReservations, computeAverageNights, computeAverageCA } from "../utils/dataUtils";
+} from '@mui/material';
+import { TrendingUp, TrendingDown } from '@mui/icons-material';
+import UrssafBox from './UrssafBox';
+import ProgressBarImpots from './ProgressBarImpots';
+import { computeAverageReservations, computeAverageNights, computeAverageCA } from '../utils/dataUtils';
 
+// Liste des mois pour le sélecteur de période
 const months = [
-  { value: null, label: "-- année entière --" },
-  { value: 1, label: "Janvier" },
-  { value: 2, label: "Février" },
-  { value: 3, label: "Mars" },
-  { value: 4, label: "Avril" },
-  { value: 5, label: "Mai" },
-  { value: 6, label: "Juin" },
-  { value: 7, label: "Juillet" },
-  { value: 8, label: "Août" },
-  { value: 9, label: "Septembre" },
-  { value: 10, label: "Octobre" },
-  { value: 11, label: "Novembre" },
-  { value: 12, label: "Décembre" },
+  { value: null, label: '-- année entière --' },
+  { value: 1, label: 'Janvier' },
+  { value: 2, label: 'Février' },
+  { value: 3, label: 'Mars' },
+  { value: 4, label: 'Avril' },
+  { value: 5, label: 'Mai' },
+  { value: 6, label: 'Juin' },
+  { value: 7, label: 'Juillet' },
+  { value: 8, label: 'Août' },
+  { value: 9, label: 'Septembre' },
+  { value: 10, label: 'Octobre' },
+  { value: 11, label: 'Novembre' },
+  { value: 12, label: 'Décembre' },
 ];
 
 function Header({
@@ -41,14 +43,15 @@ function Header({
   const avgNights = computeAverageNights(allEntries, selectedYear, selectedMonth);
   const avgCA = computeAverageCA(allEntries, selectedYear, selectedMonth);
   return (
-    <Paper elevation={2} sx={{ p: 3, mb: 2, borderRadius: 4, bgcolor: "#fff", boxShadow: "0 4px 32px #ebebeb" }}>
-      <Stack direction={{ xs: "column", sm: "row" }} spacing={3} alignItems="center" justifyContent="space-between">
-        <Box display="flex" gap={2} flexWrap="wrap">
-          <FormControl size="small" sx={{ minWidth: 120 }}>
+    <Paper elevation={2} sx={{ p: 3, mb: 2, borderRadius: 4, bgcolor: '#fff', boxShadow: '0 4px 32px #ebebeb' }}>
+      {/* Filtres de sélection de période */}
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={3} alignItems='center' justifyContent='space-between'>
+        <Box display='flex' gap={2} flexWrap='wrap'>
+          <FormControl size='small' sx={{ minWidth: 120 }}>
             <InputLabel>Année</InputLabel>
             <Select
               value={selectedYear}
-              label="Année"
+              label='Année'
               onChange={e => setSelectedYear(e.target.value)}
             >
               {availableYears.map(year => (
@@ -57,43 +60,43 @@ function Header({
             </Select>
           </FormControl>
 
-          <FormControl size="small" sx={{ minWidth: 150 }}>
+          <FormControl size='small' sx={{ minWidth: 150 }}>
             <InputLabel>Mois</InputLabel>
             <Select
               value={selectedMonth}
-              label="Mois"
+              label='Mois'
               onChange={e => setSelectedMonth(e.target.value)}
             >
-              {months.map(month =>
-                <MenuItem key={month.value || "all"} value={month.value}>
+              {months.map(month => (
+                <MenuItem key={month.value || 'all'} value={month.value}>
                   {month.label}
                 </MenuItem>
-              )}
+              ))}
             </Select>
           </FormControl>
         </Box>
 
         <Box>
-          <Stack direction="row" spacing={2}>
+          <Stack direction='row' spacing={2}>
             <FormControlLabel
               control={
                 <Switch
                   checked={showUrssaf}
                   onChange={e => setShowUrssaf(e.target.checked)}
-                  color="primary"
+                  color='primary'
                 />
               }
-              label="Mode déclaration"
+              label='Mode déclaration'
             />
             <FormControlLabel
               control={
                 <Switch
                   checked={showStats}
                   onChange={e => setShowStats(e.target.checked)}
-                  color="primary"
+                  color='primary'
                 />
               }
-              label="Stats"
+              label='Stats'
             />
           </Stack>
         </Box>
@@ -107,12 +110,14 @@ function Header({
 
       <Divider sx={{ my: 2 }} />
 
+      {/* Bloc de statistiques globales */}
       <Stack direction={{ xs: "column", sm: "row" }} spacing={2} alignItems="center" justifyContent="center">
         <HeaderStat label="Total réservations" value={globalStats.totalReservations} average={avgReservations} showStats={showStats} />
         <HeaderStat label="Total nuits réservées" value={globalStats.totalNights} average={avgNights} showStats={showStats} />
         <HeaderStat label="Chiffre d’affaire brut" value={globalStats.totalCA} average={avgCA} isCurrency showStats={showStats} />
       </Stack>
 
+      {/* Barre d'impôt globale */}
       <Box mt={5} sx={{ maxWidth: "60%", mx: "auto" }}>
         <ProgressBarImpots caBrut={caBrut} caNet={caNet} impot={impot} />
       </Box>

--- a/src/components/NuiteesPieChart.jsx
+++ b/src/components/NuiteesPieChart.jsx
@@ -1,22 +1,25 @@
-import React from "react";
-import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from "recharts";
+// Camembert affichant la répartition des nuitées par type de paiement
+import React from 'react';
+import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
 
+// Palette de couleurs pour différencier les segments
 const COLORS = [
-  "#2D8CFF", "#43B77D", "#F5A623", "#7E5BEF", "#FE5C73",
-  "#4CC3FA", "#FCBE5E", "#6BCB77", "#FFD700", "#BB86FC"
+  '#2D8CFF', '#43B77D', '#F5A623', '#7E5BEF', '#FE5C73',
+  '#4CC3FA', '#FCBE5E', '#6BCB77', '#FFD700', '#BB86FC'
 ];
 
 function NuiteesPieChart({ nuitees }) {
+  // Transformation de l'objet en tableau exploitable par Recharts
   const data = Object.entries(nuitees || {})
     .filter(([, value]) => value > 0)
     .map(([name, value]) => ({ name, value: Math.round(value * 100) / 100 }));
 
   if (!data.length) {
-    return <div style={{ color: "#bdbdbd", fontSize: 12 }}>Aucune nuitée</div>;
+    return <div style={{ color: '#bdbdbd', fontSize: 12 }}>Aucune nuitée</div>;
   }
 
   return (
-    <ResponsiveContainer width="100%" height={120}>
+    <ResponsiveContainer width='100%' height={120}>
       <PieChart>
         <Pie
           data={data}
@@ -26,7 +29,7 @@ function NuiteesPieChart({ nuitees }) {
           cy="50%"
           innerRadius={28}
           outerRadius={45}
-          fill="#8884d8"
+          fill='#8884d8'
           labelLine={false}
           isAnimationActive
         >
@@ -35,10 +38,10 @@ function NuiteesPieChart({ nuitees }) {
           ))}
         </Pie>
         <Legend
-          verticalAlign="middle"
-          align="right"
-          iconType="circle"
-          layout="vertical"
+          verticalAlign='middle'
+          align='right'
+          iconType='circle'
+          layout='vertical'
           formatter={(value, entry) => `${value} : ${entry.payload.value}`}
           wrapperStyle={{
             fontSize: 12,

--- a/src/components/OccupationGauge.jsx
+++ b/src/components/OccupationGauge.jsx
@@ -1,7 +1,8 @@
-import React from "react";
-import GaugeChart from "react-gauge-chart";
-import { Box, Stack, Typography } from "@mui/material";
-import { color } from "chart.js/helpers";
+// Affiche des jauges de taux d'occupation ou de CA par année
+import React from 'react';
+import GaugeChart from 'react-gauge-chart';
+import { Box, Stack, Typography } from '@mui/material';
+import { color } from 'chart.js/helpers';
 
 // ---- VARIABLES DE COULEURS (modifiable ici ou importer depuis theme.js) ----
 const GAUGE_MAIN_COLOR      = "#ce1273ff";    // Couleur de la jauge sélectionnée
@@ -18,11 +19,11 @@ const FONT_WEIGHT_DEFAULT   = 400;
 
 function OccupationGauge({ occupations, selectedYear, selectedMonth, showCA, caByYear, maxCA }) {
   return (
-    <Stack direction="row" gap={2} alignItems="flex-end" justifyContent="center" flexWrap="wrap">
+    <Stack direction='row' gap={2} alignItems='flex-end' justifyContent='center' flexWrap='wrap'>
       {occupations.map(({ year, occupation }) => (
-        <Box key={year} align="center" sx={{ minWidth: 80 }}>
+        <Box key={year} align='center' sx={{ minWidth: 80 }}>
           <GaugeChart
-            id={`gauge-${year}-${showCA ? "CA" : "occ"}`}
+            id={`gauge-${year}-${showCA ? 'CA' : 'occ'}`}
             nrOfLevels={10}
             percent={
               showCA
@@ -31,26 +32,26 @@ function OccupationGauge({ occupations, selectedYear, selectedMonth, showCA, caB
             }
             colors={
               year === selectedYear
-                ? ["#d81060ff", "#d71163ff"]
-                : ["#d2d2d2", "#f7f7f7"]
+                ? ['#d81060ff', '#d71163ff']
+                : ['#d2d2d2', '#f7f7f7']
             }
             arcWidth={0.23}
             hideText
-            needleColor="#2f2b2bff"
+            needleColor='#2f2b2bff'
             style={{ width: 60, height: 27}}
           />
           <Typography
-            variant="caption"
+            variant='caption'
             sx={{
-              color: year === selectedYear ? "#d71163ff" : "#bdbdbd",
+              color: year === selectedYear ? '#d71163ff' : '#bdbdbd',
               fontWeight: year === selectedYear ? 700 : 400
             }}
           >
             {year}
           </Typography>&nbsp;-&nbsp;
-          <Typography variant="caption" sx={{ color: year === selectedYear ? "#d71163ff" : "#bdbdbd", fontSize: 11 }}>
+          <Typography variant='caption' sx={{ color: year === selectedYear ? '#d71163ff' : '#bdbdbd', fontSize: 11 }}>
             {showCA
-              ? (caByYear[year] || 0).toLocaleString("fr-FR", { style: "currency", currency: "EUR" })
+              ? (caByYear[year] || 0).toLocaleString('fr-FR', { style: 'currency', currency: 'EUR' })
               : `${Math.round((occupation || 0) * 100)}%`}
           </Typography>
         </Box>

--- a/src/components/PaymentPieChart.jsx
+++ b/src/components/PaymentPieChart.jsx
@@ -1,32 +1,35 @@
-import React from "react";
-import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from "recharts";
+// Camembert montrant la répartition du chiffre d'affaires par mode de paiement
+import React from 'react';
+import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
 
+// Palette de couleurs pour les segments
 const COLORS = [
-  "#2D8CFF", "#43B77D", "#F5A623", "#7E5BEF", "#FE5C73",
-  "#4CC3FA", "#FCBE5E", "#6BCB77", "#FFD700", "#BB86FC"
+  '#2D8CFF', '#43B77D', '#F5A623', '#7E5BEF', '#FE5C73',
+  '#4CC3FA', '#FCBE5E', '#6BCB77', '#FFD700', '#BB86FC'
 ];
 
 function PaymentPieChart({ payments }) {
-  const data = Object.entries(payments || {}).map(([name, value], i) => ({
+  // Conversion de l'objet en tableau et arrondi des valeurs
+  const data = Object.entries(payments || {}).map(([name, value]) => ({
     name, value: Math.round(value * 100) / 100
   }));
 
   if (!data.length) {
-    return <div style={{ color: "#bdbdbd", fontSize: 12 }}>Aucun paiement</div>;
+    return <div style={{ color: '#bdbdbd', fontSize: 12 }}>Aucun paiement</div>;
   }
 
   return (
-    <ResponsiveContainer width="100%" height={120}>
+    <ResponsiveContainer width='100%' height={120}>
       <PieChart>
         <Pie
           data={data}
-          dataKey="value"
-          nameKey="name"
-          cx="50%"
-          cy="50%"
+          dataKey='value'
+          nameKey='name'
+          cx='50%'
+          cy='50%'
           innerRadius={28}
           outerRadius={45}
-          fill="#8884d8"
+          fill='#8884d8'
           labelLine={false}
           isAnimationActive
         >
@@ -34,21 +37,22 @@ function PaymentPieChart({ payments }) {
             <Cell key={entry.name} fill={COLORS[i % COLORS.length]} />
           ))}
         </Pie>
-<Legend
-  verticalAlign="middle"
-  align="right"
-  iconType="circle"
-  layout="vertical"
-  wrapperStyle={{
-    fontSize: 12,
-    marginLeft: 8,
-    top: 15,
-    minHeight: 100, // ou ajuste à 80, 110, etc. selon ce qui te paraît le plus équilibré
-  }}
-/>
+        <Legend
+          verticalAlign='middle'
+          align='right'
+          iconType='circle'
+          layout='vertical'
+          wrapperStyle={{
+            fontSize: 12,
+            marginLeft: 8,
+            top: 15,
+            minHeight: 100 // Hauteur minimale pour un affichage correct
+          }}
+        />
       </PieChart>
     </ResponsiveContainer>
   );
 }
 
 export default PaymentPieChart;
+

--- a/src/components/ProgressBarImpots.jsx
+++ b/src/components/ProgressBarImpots.jsx
@@ -1,28 +1,29 @@
-import React from "react";
-import { Box, Typography } from "@mui/material";
+// Barre de progression indiquant la part d'impôt sur le CA
+import React from 'react';
+import { Box, Typography } from '@mui/material';
 
 function ProgressBarImpots({ caBrut, caNet, impot }) {
-  // 94% en couleur, 6% en gris
+  // 94 % en vert (net) et 6 % en gris (impôt)
   const percent = caBrut === 0 ? 0 : (caNet / caBrut) * 100;
   return (
     <Box>
-      <Box display="flex" alignItems="center" gap={1}>
-        <Box sx={{ flex: 1, height: 8, borderRadius: 5, background: "#e0e0e0", position: "relative", overflow: "hidden" }}>
+      <Box display='flex' alignItems='center' gap={1}>
+        <Box sx={{ flex: 1, height: 8, borderRadius: 5, background: '#e0e0e0', position: 'relative', overflow: 'hidden' }}>
           <Box sx={{
             width: `${percent}%`,
             height: 8,
-            bgcolor: "#43B77D",
+            bgcolor: '#43B77D',
             borderRadius: 5,
-            transition: "width .5s"
+            transition: 'width .5s'
           }} />
         </Box>
-        <Typography variant="caption" color="#bdbdbd" minWidth={45}>
+        <Typography variant='caption' color='#bdbdbd' minWidth={45}>
           6% impôt
         </Typography>
       </Box>
-      <Box display="flex" justifyContent="space-between" mt={0.5}>
-        <Typography variant="caption" color="#43B77D">CA net : {caNet.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })}</Typography>
-        <Typography variant="caption" color="#bdbdbd">Impôt : {impot.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })}</Typography>
+      <Box display='flex' justifyContent='space-between' mt={0.5}>
+        <Typography variant='caption' color='#43B77D'>CA net : {caNet.toLocaleString('fr-FR', { style: 'currency', currency: 'EUR' })}</Typography>
+        <Typography variant='caption' color='#bdbdbd'>Impôt : {impot.toLocaleString('fr-FR', { style: 'currency', currency: 'EUR' })}</Typography>
       </Box>
     </Box>
   );

--- a/src/components/UrssafBox.jsx
+++ b/src/components/UrssafBox.jsx
@@ -1,32 +1,33 @@
-import React from "react";
-import { Paper, Typography, Stack } from "@mui/material";
-import { computeUrssaf, computeChequeVirementNights } from "../utils/dataUtils";
+// Encadré récapitulatif des montants URSSAF et nuitées par gîte
+import React from 'react';
+import { Paper, Typography, Stack } from '@mui/material';
+import { computeUrssaf, computeChequeVirementNights } from '../utils/dataUtils';
 
 function UrssafBox({ data, selectedYear, selectedMonth }) {
   const { urssafSeb, urssafSoazig } = computeUrssaf(data, selectedYear, selectedMonth);
   const nightsByGite = computeChequeVirementNights(data, selectedYear, selectedMonth);
-  const gites = ["Phonsine", "Gree", "Edmond", "Liberté"];
+  const gites = ['Phonsine', 'Gree', 'Edmond', 'Liberté'];
   return (
-    <Paper elevation={0} sx={{ bgcolor: "#f7f8fa", borderRadius: 3, p: 2, mb: 1, border: "1px solid #e0e0e0" }}>
-      <Stack direction={{ xs: "column", sm: "row" }} spacing={3} alignItems="center" justifyContent="center">
+    <Paper elevation={0} sx={{ bgcolor: '#f7f8fa', borderRadius: 3, p: 2, mb: 1, border: '1px solid #e0e0e0' }}>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={3} alignItems='center' justifyContent='center'>
         <Typography>
-          <span style={{ fontWeight: 700, color: "#2D8CFF" }}>URSSAF Sébastien : </span>
+          <span style={{ fontWeight: 700, color: '#2D8CFF' }}>URSSAF Sébastien : </span>
           <span style={{ fontWeight: 500 }}>
-            {urssafSeb.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })}
+            {urssafSeb.toLocaleString('fr-FR', { style: 'currency', currency: 'EUR' })}
           </span>
         </Typography>
         <Typography>
-          <span style={{ fontWeight: 700, color: "#43B77D" }}>URSSAF Soazig : </span>
+          <span style={{ fontWeight: 700, color: '#43B77D' }}>URSSAF Soazig : </span>
           <span style={{ fontWeight: 500 }}>
-            {urssafSoazig.toLocaleString("fr-FR", { style: "currency", currency: "EUR" })}
+            {urssafSoazig.toLocaleString('fr-FR', { style: 'currency', currency: 'EUR' })}
           </span>
         </Typography>
       </Stack>
-      <Stack direction="row" spacing={2} justifyContent="center" mt={1}>
+      <Stack direction='row' spacing={2} justifyContent='center' mt={1}>
         {gites.map(name => (
-          <Stack key={name} spacing={0.5} alignItems="center">
-            <Typography variant="caption" fontWeight={700}>{name}</Typography>
-            <Typography variant="caption">{nightsByGite[name] || 0} nuitées</Typography>
+          <Stack key={name} spacing={0.5} alignItems='center'>
+            <Typography variant='caption' fontWeight={700}>{name}</Typography>
+            <Typography variant='caption'>{nightsByGite[name] || 0} nuitées</Typography>
           </Stack>
         ))}
       </Stack>


### PR DESCRIPTION
## Summary
- Arrondi des axes des graphiques de chiffre d'affaires à la centaine supérieure avec paliers de 100 € pour uniformiser l'échelle
- Enrichissement du README et commentaires détaillés en français dans les composants
- Mise à jour des métadonnées du projet dans `package.json`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688d256158c483228cac487cc7ff5822